### PR TITLE
Error handling for login

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,5 @@
 {
     "@@locale": "en",
-
     "continueWatching": "Continue Watching",
     "recentlyAddedMovies": "Recently Added Movies",
     "recentlyAddedShows": "Recently Added Shows",
@@ -95,6 +94,11 @@
     "login": "Login",
     "username": "Username",
     "password": "Password",
+    "emptyAddress": "Empty Server Address",
+    "emptyUsername": "Empty Username",
+    "emptyPassword": "Empty Password",
+    "emptyFields": "Please fill out the following fields",
+    "errorConnectingToServer": "Error connecting to server",
     "webDemoNote": "This is a demo version of Jellyflix. To use it, you can use the following credentials: \n\nServer Address: https://demo.jellyfin.org/stable \nUser Name: demo \nand empty password \n\n",
     "quality": "Quality",
     "audio": "Audio",
@@ -120,7 +124,7 @@
           }
         }
       },
-    "minutes": "{count} min",  
+    "minutes": "{count} min",
     "@minutes": {
         "placeholders": {
             "count": {
@@ -181,5 +185,5 @@
     "info": "Info",
     "showPrimaryForEpisodes": "Show primary image instead of series poster in Continue Watching",
     "appName": "Jellyflix"
-    
+
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -42,7 +42,7 @@ class LoginScreen extends HookConsumerWidget {
                     decoration: InputDecoration(
                       border: const OutlineInputBorder(),
                       labelText: AppLocalizations.of(context)!.serverAddress,
-                      hintText: 'host',
+                      hintText: 'http://',
                     ),
                   ),
                 ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -80,20 +80,24 @@ class LoginScreen extends HookConsumerWidget {
                         try {
                           var missingFields = '';
                           if (userName.text.isEmpty) {
-                            missingFields += 'Empty username\n\n';
+                            missingFields +=
+                                '${AppLocalizations.of(context)!.emptyUsername}\n\n';
                           }
                           if (password.text.isEmpty) {
-                            missingFields += 'Empty password\n\n';
+                            missingFields +=
+                                '${AppLocalizations.of(context)!.emptyPassword}\n\n';
                           }
                           if (serverAddress.text.isEmpty) {
-                            missingFields += 'Empty address\n\n';
+                            missingFields +=
+                                '${AppLocalizations.of(context)!.emptyAddress}\n\n';
                           }
 
                           if (missingFields.isNotEmpty) {
                             await showInfoDialog(
                               context,
-                              const Text(
-                                  'Please fill out the following fields'),
+                              Text(
+                                AppLocalizations.of(context)!.emptyFields,
+                              ),
                               content: Text(missingFields),
                             );
                             return;
@@ -112,7 +116,8 @@ class LoginScreen extends HookConsumerWidget {
                           if (!context.mounted) return;
                           await showInfoDialog(
                             context,
-                            const Text('Error connecting to server'),
+                            Text(AppLocalizations.of(context)!
+                                .errorConnectingToServer),
                             content: Text(e.toString()),
                           );
                           return;

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -78,12 +78,23 @@ class LoginScreen extends HookConsumerWidget {
                     child: FilledButton(
                       onPressed: () async {
                         try {
-                          if (userName.text.isEmpty ||
-                              password.text.isEmpty ||
-                              serverAddress.text.isEmpty) {
+                          var missingFields = '';
+                          if (userName.text.isEmpty) {
+                            missingFields += 'Empty username\n\n';
+                          }
+                          if (password.text.isEmpty) {
+                            missingFields += 'Empty password\n\n';
+                          }
+                          if (serverAddress.text.isEmpty) {
+                            missingFields += 'Empty address\n\n';
+                          }
+
+                          if (missingFields.isNotEmpty) {
                             await showInfoDialog(
                               context,
-                              const Text('Missing information'),
+                              const Text(
+                                  'Please fill out the following fields'),
+                              content: Text(missingFields),
                             );
                             return;
                           }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -39,6 +39,7 @@ class LoginScreen extends HookConsumerWidget {
                   padding: const EdgeInsets.symmetric(vertical: 10.0),
                   child: TextField(
                     controller: serverAddress,
+                    autofillHints: const [AutofillHints.url],
                     decoration: InputDecoration(
                       border: const OutlineInputBorder(),
                       labelText: AppLocalizations.of(context)!.serverAddress,
@@ -49,6 +50,7 @@ class LoginScreen extends HookConsumerWidget {
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 10.0),
                   child: TextField(
+                    autofillHints: const [AutofillHints.username],
                     controller: userName,
                     decoration: InputDecoration(
                       border: const OutlineInputBorder(),
@@ -61,6 +63,7 @@ class LoginScreen extends HookConsumerWidget {
                   child: TextField(
                     obscureText: true,
                     controller: password,
+                    autofillHints: const [AutofillHints.password],
                     decoration: InputDecoration(
                       border: const OutlineInputBorder(),
                       labelText: AppLocalizations.of(context)!.password,

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -10,6 +10,7 @@ class AuthService {
   final DatabaseService _databaseService;
 
   final StreamController<bool> _authStateStream = StreamController();
+
   Stream<bool> get authStateChange => _authStateStream.stream;
 
   Future<bool> get isAuthenticated => _authStateStream.stream.last;
@@ -60,7 +61,8 @@ class AuthService {
           user.serverAdress!, user.name!, user.password!);
     } catch (e) {
       if (user.serverAdress!.split(":").last != "8096" &&
-          user.serverAdress!.split(":").length == 2) {
+          user.serverAdress!.split(":").length == 2 &&
+          user.serverAdress!.split(":").first == 'http') {
         user.serverAdress = "${user.serverAdress}:8096";
         user = await _apiService.login(
             user.serverAdress!, user.name!, user.password!);


### PR DESCRIPTION
## Ui changes

Added specific messages for certain HTTP codes. If a code does not match a specific code, it defaults to the standard error.

![err](https://github.com/user-attachments/assets/723cadca-f495-40be-b62a-880dc5d6b7a8)

Added error handling according to todo, a simple dialog for now. 

![image](https://github.com/user-attachments/assets/4f46d449-e96f-45ac-8d7a-3d45e0ac745e)


Added a check for empty inputs; if any input fields are empty, this will appear.

![image](https://github.com/user-attachments/assets/6a53bff3-a1f8-4be5-b5fb-4e23e298efa6)

## bug fixes

There was also a bug in the auth logic 

The if condition adds a port regardless of the protocol, which will cause a tls mismatch error if we put https address and the error handler adds the port.

relevant line

```dart
if (user.serverAdress!.split(":").last != "8096" &&
          user.serverAdress!.split(":").length == 2 
```

adds a HTTP check 
``` dart
if (user.serverAdress!.split(":").last != "8096" &&
          user.serverAdress!.split(":").length == 2 &&
          user.serverAdress!.split(":").first == 'http')
```

```dart
try {
      user = await _apiService.login(
          user.serverAdress!, user.name!, user.password!);
    } catch (e) {
      if (user.serverAdress!.split(":").last != "8096" &&
          user.serverAdress!.split(":").length == 2 &&
          user.serverAdress!.split(":").first == 'http') {
        user.serverAdress = "${user.serverAdress}:8096";
        user = await _apiService.login(
            user.serverAdress!, user.name!, user.password!);
      } else {
        rethrow;
      }
    }
```

