### PR TITLE
Login error handling

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,5 @@
 {
     "@@locale": "en",
-
     "continueWatching": "Continue Watching",
     "recentlyAddedMovies": "Recently Added Movies",
     "recentlyAddedShows": "Recently Added Shows",
@@ -95,6 +94,11 @@
     "login": "Login",
     "username": "Username",
     "password": "Password",
+    "emptyAddress": "Empty Server Address",
+    "emptyUsername": "Empty Username",
+    "emptyPassword": "Empty Password",
+    "emptyFields": "Please fill out the following fields",
+    "errorConnectingToServer": "Error connecting to server",
     "webDemoNote": "This is a demo version of Jellyflix. To use it, you can use the following credentials: \n\nServer Address: https://demo.jellyfin.org/stable \nUser Name: demo \nand empty password \n\n",
     "quality": "Quality",
     "audio": "Audio",
@@ -120,7 +124,7 @@
           }
         }
       },
-    "minutes": "{count} min",  
+    "minutes": "{count} min",
     "@minutes": {
         "placeholders": {
             "count": {
@@ -181,5 +185,5 @@
     "info": "Info",
     "showPrimaryForEpisodes": "Show primary image instead of series poster in Continue Watching",
     "appName": "Jellyflix"
-    
+
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -145,7 +145,6 @@ class LoginScreen extends HookConsumerWidget {
       final missingFields = formatMissingFields(
         context,
         username,
-        password,
         serverAddress,
       );
       if (missingFields.isNotEmpty) {
@@ -229,14 +228,14 @@ class LoginScreen extends HookConsumerWidget {
     );
   }
 
-  String formatMissingFields(BuildContext context, String username,
-      String password, String serverAddress) {
+  String formatMissingFields(
+    BuildContext context,
+    String username,
+    String serverAddress,
+  ) {
     var missingFields = '';
     if (username.isEmpty) {
       missingFields += '${AppLocalizations.of(context)!.emptyUsername}\n\n';
-    }
-    if (password.isEmpty) {
-      missingFields += '${AppLocalizations.of(context)!.emptyPassword}\n\n';
     }
     if (serverAddress.isEmpty) {
       missingFields += '${AppLocalizations.of(context)!.emptyAddress}\n\n';
@@ -246,16 +245,17 @@ class LoginScreen extends HookConsumerWidget {
   }
 
   String formatHttpErrorCode(Response? resp) {
+    // todo PLACEHOLDER MESSAGES NOT FINAL
     var message = '';
     switch (resp!.statusCode) {
       case 400:
         message =
-            'Something went wrong while making the request, this is probably a issue within Jellyflix, please open a github issue';
+            'The server could not understand the request, if you are using proxies check the configuration, if the issue still persists let us know';
       case 401:
         message = 'Your username or password may be incorrect';
       case 403:
         message =
-            'The Server has probably banned this IP, please contact your admin to resolve this issue';
+            'The server is blocking request from this device, this probably means the device has been banned, please contact your admin to resolve this issue';
       default:
         message = '';
     }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,12 +1,13 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:jellyflix/models/screen_paths.dart';
 import 'package:jellyflix/models/user.dart';
 import 'package:jellyflix/providers/auth_provider.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class LoginScreen extends HookConsumerWidget {
   const LoginScreen({super.key});
@@ -16,6 +17,7 @@ class LoginScreen extends HookConsumerWidget {
     final userName = useTextEditingController();
     final password = useTextEditingController();
     final serverAddress = useTextEditingController();
+
     return Scaffold(
       appBar: AppBar(),
       body: Center(
@@ -39,9 +41,10 @@ class LoginScreen extends HookConsumerWidget {
                   child: TextField(
                     controller: serverAddress,
                     decoration: InputDecoration(
-                        border: const OutlineInputBorder(),
-                        labelText: AppLocalizations.of(context)!.serverAddress,
-                        hintText: 'http://'),
+                      border: const OutlineInputBorder(),
+                      labelText: AppLocalizations.of(context)!.serverAddress,
+                      hintText: 'http://',
+                    ),
                   ),
                 ),
                 Padding(
@@ -73,17 +76,54 @@ class LoginScreen extends HookConsumerWidget {
                     child: FilledButton(
                       onPressed: () async {
                         try {
+                          final missingFields = formatMissingFields(
+                            context,
+                            userName.text,
+                            password.text,
+                            serverAddress.text,
+                          );
+                          if (missingFields.isNotEmpty) {
+                            await showInfoDialog(
+                              context,
+                              Text(
+                                AppLocalizations.of(context)!.emptyFields,
+                              ),
+                              content: Text(missingFields),
+                            );
+                            return;
+                          }
+
                           User user = User(
-                              name: userName.text,
-                              password: password.text,
-                              serverAdress: serverAddress.text);
+                            name: userName.text,
+                            password: password.text,
+                            serverAdress: serverAddress.text,
+                          );
                           await ref.read(authProvider).login(user);
                           if (context.mounted) {
                             context.go(ScreenPaths.home);
                           }
+                        } on DioException catch (e) {
+                          if (!context.mounted) return;
+                          await showInfoDialog(
+                            context,
+                            Text(
+                              AppLocalizations.of(context)!
+                                  .errorConnectingToServer,
+                            ),
+                            content: e.response?.statusCode == null
+                                ? Text(e.toString())
+                                : Text(formatHttpErrorCode(e.response)),
+                          );
+                          return;
                         } catch (e) {
-                          // TODO: show error message to user
-                          //print(e);
+                          if (!context.mounted) return;
+                          await showInfoDialog(
+                            context,
+                            Text(AppLocalizations.of(context)!
+                                .errorConnectingToServer),
+                            content: Text(e.toString()),
+                          );
+                          return;
                         }
                       },
                       child: Text(AppLocalizations.of(context)!.login),
@@ -99,5 +139,64 @@ class LoginScreen extends HookConsumerWidget {
         ),
       )),
     );
+  }
+
+  Future<void> showInfoDialog(
+    BuildContext context,
+    Widget title, {
+    Widget? content,
+  }) async {
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: title,
+        content: content,
+        actions: [
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            child: const Text('Ok'),
+          )
+        ],
+      ),
+    );
+  }
+
+  String formatMissingFields(BuildContext context, String username,
+      String password, String serverAddress) {
+    var missingFields = '';
+    if (username.isEmpty) {
+      missingFields += '${AppLocalizations.of(context)!.emptyUsername}\n\n';
+    }
+    if (password.isEmpty) {
+      missingFields += '${AppLocalizations.of(context)!.emptyPassword}\n\n';
+    }
+    if (serverAddress.isEmpty) {
+      missingFields += '${AppLocalizations.of(context)!.emptyAddress}\n\n';
+    }
+
+    return missingFields;
+  }
+
+  String formatHttpErrorCode(Response? resp) {
+    var message = '';
+    switch (resp!.statusCode) {
+      case 400:
+        message =
+            'Something went wrong while making the request, this is probably a issue within Jellyflix, please open a github issue';
+      case 401:
+        message = 'Your username or password may be incorrect';
+      case 403:
+        message =
+            'The Server has probably banned this IP, please contact your admin to resolve this issue';
+      default:
+        message = '';
+    }
+
+    return '$message\n\n'
+            'Http Code: ${resp.statusCode ?? 'Unknown'}\n\n'
+            'Http Response: ${resp.statusMessage ?? 'Unknown'}\n\n'
+        .trim();
   }
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
@@ -20,129 +21,162 @@ class LoginScreen extends HookConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(),
-      body: Center(
-          child: SingleChildScrollView(
-        child: SizedBox(
-          width: 400,
-          child: Padding(
-            padding: const EdgeInsets.all(20.0),
-            child: AutofillGroup(
-              child: Column(
-                children: [
-                  Text(AppLocalizations.of(context)!.appName,
-                      style: Theme.of(context).textTheme.displaySmall),
-                  Text(
-                    AppLocalizations.of(context)!.appSubtitle,
-                  ),
-                  const SizedBox(
-                    height: 20,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 10.0),
-                    child: TextField(
-                      controller: serverAddress,
-                      decoration: InputDecoration(
-                        border: const OutlineInputBorder(),
-                        labelText: AppLocalizations.of(context)!.serverAddress,
-                        hintText: 'http://',
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 10.0),
-                    child: TextField(
-                      controller: userName,
-                      autofillHints: const [AutofillHints.username],
-                      decoration: InputDecoration(
-                        border: const OutlineInputBorder(),
-                        labelText: AppLocalizations.of(context)!.username,
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 10.0),
-                    child: TextField(
-                      obscureText: true,
-                      autofillHints: const [AutofillHints.password],
-                      controller: password,
-                      decoration: InputDecoration(
-                        border: const OutlineInputBorder(),
-                        labelText: AppLocalizations.of(context)!.password,
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 10.0),
-                    child: SizedBox(
-                      height: 45,
-                      width: 100,
-                      child: FilledButton(
-                        onPressed: () async {
-                          try {
-                            final missingFields = formatMissingFields(
-                              context,
-                              userName.text,
-                              password.text,
-                              serverAddress.text,
-                            );
-                            if (missingFields.isNotEmpty) {
-                              await showInfoDialog(
+      body: CallbackShortcuts(
+        bindings: <ShortcutActivator, VoidCallback>{
+          const SingleActivator(LogicalKeyboardKey.enter): () async {
+            print('pressing enter');
+            await login(
+              context,
+              ref,
+              username: userName.text,
+              serverAddress: serverAddress.text,
+              password: password.text,
+            );
+          }
+        },
+        child: FocusScope(
+          // needed for enter shortcut to work
+          autofocus: true,
+          child: Center(
+            child: SingleChildScrollView(
+              child: SizedBox(
+                width: 400,
+                child: Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: AutofillGroup(
+                    child: Column(
+                      children: [
+                        Text(AppLocalizations.of(context)!.appName,
+                            style: Theme.of(context).textTheme.displaySmall),
+                        Text(
+                          AppLocalizations.of(context)!.appSubtitle,
+                        ),
+                        const SizedBox(
+                          height: 20,
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 10.0),
+                          child: TextField(
+                            controller: serverAddress,
+                            decoration: InputDecoration(
+                              border: const OutlineInputBorder(),
+                              labelText:
+                                  AppLocalizations.of(context)!.serverAddress,
+                              hintText: 'http://',
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 10.0),
+                          child: TextField(
+                            controller: userName,
+                            autofillHints: const [AutofillHints.username],
+                            decoration: InputDecoration(
+                              border: const OutlineInputBorder(),
+                              labelText: AppLocalizations.of(context)!.username,
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 10.0),
+                          child: TextField(
+                            obscureText: true,
+                            autofillHints: const [AutofillHints.password],
+                            textInputAction: TextInputAction.go,
+                            controller: password,
+                            decoration: InputDecoration(
+                              border: const OutlineInputBorder(),
+                              labelText: AppLocalizations.of(context)!.password,
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 10.0),
+                          child: SizedBox(
+                            height: 45,
+                            width: 100,
+                            child: FilledButton(
+                              onPressed: () async => await login(
                                 context,
-                                Text(
-                                  AppLocalizations.of(context)!.emptyFields,
-                                ),
-                                content: Text(missingFields),
-                              );
-                              return;
-                            }
-
-                            User user = User(
-                              name: userName.text,
-                              password: password.text,
-                              serverAdress: serverAddress.text,
-                            );
-                            await ref.read(authProvider).login(user);
-                            if (context.mounted) {
-                              context.go(ScreenPaths.home);
-                            }
-                          } on DioException catch (e) {
-                            if (!context.mounted) return;
-                            await showInfoDialog(
-                              context,
-                              Text(
-                                AppLocalizations.of(context)!
-                                    .errorConnectingToServer,
+                                ref,
+                                username: userName.text,
+                                serverAddress: serverAddress.text,
+                                password: password.text,
                               ),
-                              content: e.response?.statusCode == null
-                                  ? Text(e.toString())
-                                  : Text(formatHttpErrorCode(e.response)),
-                            );
-                            return;
-                          } catch (e) {
-                            if (!context.mounted) return;
-                            await showInfoDialog(
-                              context,
-                              Text(AppLocalizations.of(context)!
-                                  .errorConnectingToServer),
-                              content: Text(e.toString()),
-                            );
-                            return;
-                          }
-                        },
-                        child: Text(AppLocalizations.of(context)!.login),
-                      ),
+                              child: Text(AppLocalizations.of(context)!.login),
+                            ),
+                          ),
+                        ),
+                        kIsWeb
+                            ? Text(AppLocalizations.of(context)!.webDemoNote)
+                            : const SizedBox(),
+                      ],
                     ),
                   ),
-                  kIsWeb
-                      ? Text(AppLocalizations.of(context)!.webDemoNote)
-                      : const SizedBox(),
-                ],
+                ),
               ),
             ),
           ),
         ),
-      )),
+      ),
     );
+  }
+
+  Future<void> login(
+    BuildContext context,
+    WidgetRef ref, {
+    required String serverAddress,
+    required String username,
+    required String password,
+  }) async {
+    try {
+      final missingFields = formatMissingFields(
+        context,
+        username,
+        password,
+        serverAddress,
+      );
+      if (missingFields.isNotEmpty) {
+        await showInfoDialog(
+          context,
+          Text(
+            AppLocalizations.of(context)!.emptyFields,
+          ),
+          content: Text(missingFields),
+        );
+        return;
+      }
+
+      User user = User(
+        name: username,
+        password: password,
+        serverAdress: serverAddress,
+      );
+      await ref.read(authProvider).login(user);
+      if (context.mounted) {
+        context.go(ScreenPaths.home);
+      }
+    } on DioException catch (e) {
+      if (!context.mounted) return;
+      await showInfoDialog(
+        context,
+        Text(
+          AppLocalizations.of(context)!.errorConnectingToServer,
+        ),
+        content: e.response?.statusCode == null
+            ? Text(e.toString())
+            : Text(formatHttpErrorCode(e.response)),
+      );
+      return;
+    } catch (e) {
+      if (!context.mounted) return;
+      await showInfoDialog(
+        context,
+        Text(AppLocalizations.of(context)!.errorConnectingToServer),
+        content: Text(e.toString()),
+      );
+      return;
+    }
   }
 
   Future<void> showInfoDialog(
@@ -152,17 +186,27 @@ class LoginScreen extends HookConsumerWidget {
   }) async {
     await showDialog(
       context: context,
-      builder: (context) => AlertDialog(
-        title: title,
-        content: content,
-        actions: [
-          ElevatedButton(
-            onPressed: () {
-              Navigator.pop(context);
-            },
-            child: const Text('Ok'),
-          )
-        ],
+      builder: (context) => CallbackShortcuts(
+        bindings: <ShortcutActivator, VoidCallback>{
+          const SingleActivator(LogicalKeyboardKey.enter): () {
+            Navigator.pop(context);
+          }
+        },
+        child: FocusScope(
+          autofocus: true,
+          child: AlertDialog(
+            title: title,
+            content: content,
+            actions: [
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+                child: const Text('Ok'),
+              )
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -10,6 +10,7 @@ class AuthService {
   final DatabaseService _databaseService;
 
   final StreamController<bool> _authStateStream = StreamController();
+
   Stream<bool> get authStateChange => _authStateStream.stream;
 
   Future<bool> get isAuthenticated => _authStateStream.stream.last;
@@ -60,7 +61,8 @@ class AuthService {
           user.serverAdress!, user.name!, user.password!);
     } catch (e) {
       if (user.serverAdress!.split(":").last != "8096" &&
-          user.serverAdress!.split(":").length == 2) {
+          user.serverAdress!.split(":").length == 2 &&
+          user.serverAdress!.split(":").first == 'http') {
         user.serverAdress = "${user.serverAdress}:8096";
         user = await _apiService.login(
             user.serverAdress!, user.name!, user.password!);

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -4,10 +4,6 @@ import 'package:jellyflix/models/user.dart';
 import 'package:jellyflix/services/api_service.dart';
 import 'package:jellyflix/services/database_service.dart';
 
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-
 class AuthService {
   final ApiService _apiService;
 
@@ -203,7 +199,7 @@ List<String> generateUrlCandidates(String input) {
   final match = rgx.firstMatch(input);
 
   if (match != null) {
-    var scheme = match.group(1) ?? ''; // add back the //
+    var scheme = match.group(1) ?? '';
     final body = match.group(2) ?? '';
     final port = match.group(3)?.substring(1) ?? ''; // Remove leading colon
     final path = match.group(4) ?? '';


### PR DESCRIPTION
## Changes

Added support for autofill so that password managers can autofill credentials.

## Ui changes

Default error handling UI.

![default](https://github.com/user-attachments/assets/692ddcdd-ce35-4635-9100-952a9b367d40)

Specific error messages for certain HTTP codes. If a response does not match a specific code, it defaults to the normal UI.

![err](https://github.com/user-attachments/assets/20b2bdb1-5d61-4b2a-b899-45e7ebe7cbce)

Added a check for empty inputs.

![missing](https://github.com/user-attachments/assets/ca5f4e71-6be7-4c60-a398-64598ed038cc)

## Bug fix

There was also a bug in the auth logic

The if condition adds a port regardless of the protocol, which will cause a tls mismatch error if we put https address and the error handler adds the port.

relevant line

```dart
if (user.serverAdress!.split(":").last != "8096" &&
          user.serverAdress!.split(":").length == 2 
```

adds a HTTP check

```dart
if (user.serverAdress!.split(":").last != "8096" &&
          user.serverAdress!.split(":").length == 2 &&
          user.serverAdress!.split(":").first == 'http')
```