### PR TITLE
feat: added autocomplete options to url input

### DIFF
--- a/lib/components/custom_autocomplete_options.dart
+++ b/lib/components/custom_autocomplete_options.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jellyflix/providers/url_autocomplete_provider.dart';
 
-class CustomAutocompleteOptions<T extends Object> extends StatelessWidget {
+class CustomAutocompleteOptions<T extends Object> extends ConsumerWidget {
   const CustomAutocompleteOptions({
     super.key,
     required this.displayStringForOption,
@@ -22,7 +24,7 @@ class CustomAutocompleteOptions<T extends Object> extends StatelessWidget {
   final double maxOptionsWidth;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final AlignmentDirectional optionsAlignment = switch (openDirection) {
       OptionsViewOpenDirection.up => AlignmentDirectional.bottomStart,
       OptionsViewOpenDirection.down => AlignmentDirectional.topStart,
@@ -51,6 +53,11 @@ class CustomAutocompleteOptions<T extends Object> extends StatelessWidget {
                   final bool highlight =
                       AutocompleteHighlightedOption.of(context) == index;
                   if (highlight) {
+                    // wrapped in a future to update the options after building
+                    Future(
+                      () => ref.read(selectedOptionProvider.notifier).state =
+                          index,
+                    );
                     SchedulerBinding.instance.addPostFrameCallback(
                         (Duration timeStamp) {
                       Scrollable.ensureVisible(context, alignment: 0.5);

--- a/lib/components/custom_autocomplete_options.dart
+++ b/lib/components/custom_autocomplete_options.dart
@@ -27,6 +27,7 @@ class CustomAutocompleteOptions<T extends Object> extends StatelessWidget {
       OptionsViewOpenDirection.up => AlignmentDirectional.bottomStart,
       OptionsViewOpenDirection.down => AlignmentDirectional.topStart,
     };
+    // taken from flutter\lib\src\material\autocomplete.dart and slightly modified
     return Align(
       alignment: optionsAlignment,
       child: Material(

--- a/lib/components/custom_autocomplete_options.dart
+++ b/lib/components/custom_autocomplete_options.dart
@@ -58,30 +58,27 @@ class CustomAutocompleteOptions<T extends Object> extends ConsumerWidget {
                     // wrapped in a future to update the options after building
                     Future(
                       () => ref.read(selectedOptionProvider.notifier).state =
-                          index,
+                          option as String,
                     );
                     SchedulerBinding.instance.addPostFrameCallback(
                         (Duration timeStamp) {
                       Scrollable.ensureVisible(context, alignment: 0.5);
                     }, debugLabel: 'AutocompleteOptions.ensureVisible');
                   }
+
                   return Container(
                     color: highlight ? Theme.of(context).focusColor : null,
                     padding: const EdgeInsets.all(16.0),
-                    child: highlight
-                        ? Platform.isAndroid ||
-                                Platform
-                                    .isIOS // do not show shortcut hint on mobile platforms
-                            ? Text(displayStringForOption(option))
-                            : Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [
-                                  Text(displayStringForOption(option)),
-                                  const SizedBox(width: 20),
-                                  const Text('Enter to fill')
-                                ],
-                              )
+                    // do not show shortcut hint on mobile platforms
+                    child: highlight && !(Platform.isAndroid || Platform.isIOS)
+                        ? Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(displayStringForOption(option)),
+                              const SizedBox(width: 20),
+                              const Text('Enter to fill')
+                            ],
+                          )
                         : Text(displayStringForOption(option)),
                   );
                 }),

--- a/lib/components/custom_autocomplete_options.dart
+++ b/lib/components/custom_autocomplete_options.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -66,7 +68,21 @@ class CustomAutocompleteOptions<T extends Object> extends ConsumerWidget {
                   return Container(
                     color: highlight ? Theme.of(context).focusColor : null,
                     padding: const EdgeInsets.all(16.0),
-                    child: Text(displayStringForOption(option)),
+                    child: highlight
+                        ? Platform.isAndroid ||
+                                Platform
+                                    .isIOS // do not show shortcut hint on mobile platforms
+                            ? Text(displayStringForOption(option))
+                            : Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Text(displayStringForOption(option)),
+                                  const SizedBox(width: 20),
+                                  const Text('Enter to fill')
+                                ],
+                              )
+                        : Text(displayStringForOption(option)),
                   );
                 }),
               );

--- a/lib/components/custom_autocomplete_options.dart
+++ b/lib/components/custom_autocomplete_options.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+class CustomAutocompleteOptions<T extends Object> extends StatelessWidget {
+  const CustomAutocompleteOptions({
+    super.key,
+    required this.displayStringForOption,
+    required this.onSelected,
+    required this.openDirection,
+    required this.options,
+    required this.maxOptionsHeight,
+    required this.maxOptionsWidth,
+  });
+
+  final AutocompleteOptionToString<T> displayStringForOption;
+
+  final AutocompleteOnSelected<T> onSelected;
+  final OptionsViewOpenDirection openDirection;
+
+  final Iterable<T> options;
+  final double maxOptionsHeight;
+  final double maxOptionsWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final AlignmentDirectional optionsAlignment = switch (openDirection) {
+      OptionsViewOpenDirection.up => AlignmentDirectional.bottomStart,
+      OptionsViewOpenDirection.down => AlignmentDirectional.topStart,
+    };
+    return Align(
+      alignment: optionsAlignment,
+      child: Material(
+        elevation: 4.0,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: maxOptionsHeight,
+            maxWidth: maxOptionsWidth,
+          ),
+          child: ListView.builder(
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            itemCount: options.length,
+            itemBuilder: (BuildContext context, int index) {
+              final T option = options.elementAt(index);
+              return InkWell(
+                onTap: () {
+                  onSelected(option);
+                },
+                child: Builder(builder: (BuildContext context) {
+                  final bool highlight =
+                      AutocompleteHighlightedOption.of(context) == index;
+                  if (highlight) {
+                    SchedulerBinding.instance.addPostFrameCallback(
+                        (Duration timeStamp) {
+                      Scrollable.ensureVisible(context, alignment: 0.5);
+                    }, debugLabel: 'AutocompleteOptions.ensureVisible');
+                  }
+                  return Container(
+                    color: highlight ? Theme.of(context).focusColor : null,
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(displayStringForOption(option)),
+                  );
+                }),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/url_autocomplete_field.dart
+++ b/lib/components/url_autocomplete_field.dart
@@ -41,14 +41,20 @@ class UrlFieldInput extends ConsumerWidget {
       textEditingController: serverAddress,
       optionsBuilder: (TextEditingValue textEditingValue) {
         final result = savedAddress.valueOrNull
-            ?.where((element) => element.serverAdress!
-                .toLowerCase()
-                .contains(textEditingValue.text.toLowerCase()))
-            .map((e) => e.serverAdress!).toSet(); // remove duplicates
+            ?.where(
+              (element) =>
+                  element.serverAdress!
+                      .toLowerCase()
+                      .contains(textEditingValue.text.toLowerCase()) &&
+                  element.serverAdress! != textEditingValue.text.toLowerCase(),
+            )
+            .map((e) => e.serverAdress!)
+            .toSet(); // remove duplicates
 
         final options = result == null || result.isEmpty
-            ? ['http://', 'https://']
-                .where((e) => e.contains(textEditingValue.text.toLowerCase()))
+            ? ['http://', 'https://'].where((e) =>
+                e.contains(textEditingValue.text.toLowerCase()) &&
+                e != textEditingValue.text.toLowerCase())
             : result;
 
         ref.watch(optionsListProvider.notifier).overwriteList(options);

--- a/lib/components/url_autocomplete_field.dart
+++ b/lib/components/url_autocomplete_field.dart
@@ -7,7 +7,6 @@ import 'package:jellyflix/models/user.dart';
 import 'package:jellyflix/providers/auth_provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:jellyflix/providers/url_autocomplete_provider.dart';
-import 'package:media_kit_video/media_kit_video_controls/src/controls/methods/video_state.dart';
 
 // Courtesy of sevenrats for the shortcuts
 
@@ -45,7 +44,7 @@ class UrlFieldInput extends ConsumerWidget {
             ?.where((element) => element.serverAdress!
                 .toLowerCase()
                 .contains(textEditingValue.text.toLowerCase()))
-            .map((e) => e.serverAdress!);
+            .map((e) => e.serverAdress!).toSet(); // remove duplicates
 
         final options = result == null || result.isEmpty
             ? ['http://', 'https://']

--- a/lib/components/url_autocomplete_field.dart
+++ b/lib/components/url_autocomplete_field.dart
@@ -17,6 +17,7 @@ class UrlFieldInput extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final savedAddress = ref.read(allProfilesProvider);
+
     // Needed to get width of the URL text field
     // so we can assign that to the autocomplete width
     final urlTextFieldKey = GlobalKey();
@@ -43,15 +44,18 @@ class UrlFieldInput extends ConsumerWidget {
                 .toLowerCase()
                 .contains(textEditingValue.text.toLowerCase()))
             .map((e) => e.serverAdress!);
+
         final options = result == null || result.isEmpty
             ? ['http://', 'https://']
                 .where((e) => e.contains(textEditingValue.text.toLowerCase()))
             : result;
+
         ref.read(optionsListProvider.notifier).overwriteList(options);
         ref.invalidate(selectedOptionProvider);
+
         return options;
       },
-      // onSelected: (option) => serverAddress.text = option,
+      onSelected: (option) => serverAddress.text = option,
       optionsViewOpenDirection: OptionsViewOpenDirection.down,
       fieldViewBuilder: (context, controller, focusNode, _) {
         return TextField(

--- a/lib/components/url_autocomplete_field.dart
+++ b/lib/components/url_autocomplete_field.dart
@@ -51,7 +51,7 @@ class UrlFieldInput extends ConsumerWidget {
                 .where((e) => e.contains(textEditingValue.text.toLowerCase()))
             : result;
 
-        ref.read(optionsListProvider.notifier).overwriteList(options);
+        ref.watch(optionsListProvider.notifier).overwriteList(options);
         ref.invalidate(selectedOptionProvider);
 
         return options;

--- a/lib/components/url_autocomplete_field.dart
+++ b/lib/components/url_autocomplete_field.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -6,6 +7,7 @@ import 'package:jellyflix/models/user.dart';
 import 'package:jellyflix/providers/auth_provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:jellyflix/providers/url_autocomplete_provider.dart';
+import 'package:media_kit_video/media_kit_video_controls/src/controls/methods/video_state.dart';
 
 // Courtesy of sevenrats for the shortcuts
 
@@ -85,7 +87,7 @@ class UrlFieldInput extends ConsumerWidget {
           onSelected: onSelected,
           options: options,
           openDirection: OptionsViewOpenDirection.down,
-          maxOptionsHeight: 100,
+          maxOptionsHeight: 150,
           maxOptionsWidth: renderBox?.size.width ?? 300,
         );
       },
@@ -103,24 +105,24 @@ class UrlFieldInput extends ConsumerWidget {
     // sometimes the optionsListProvider remains empty even after options are built
     // I don't understand why it happens, cannot recreate it and is pretty much random,
     // so its wrapped in a try catch
+    final currentOptions = ref.read(optionsListProvider);
     try {
-      final currentOptions = ref.read(optionsListProvider);
-      final user = savedAddress.valueOrNull?.firstWhere(
-        (element) =>
-            element.serverAdress!.startsWith(currentOptions[selectedInd]),
-      );
+      final option = currentOptions[selectedInd];
 
-      if (user != null) {
-        controller.text = user.serverAdress!;
-        // Move the cursor to the end of the text
-        controller.selection = TextSelection.fromPosition(
-          TextPosition(offset: controller.text.length),
-        );
-      }
+      controller.text = option;
+      // Move the cursor to the end of the text
+      controller.selection = TextSelection.fromPosition(
+        TextPosition(offset: controller.text.length),
+      );
     } catch (e) {
-      print('Option list accessed a element out of bounds');
-      print(e);
+      if (kDebugMode) {
+        print('Option list accessed a element out of bounds');
+        print('The following are the available options');
+        print(currentOptions);
+        print('Index that was accessed');
+        print(selectedInd);
+        print(e);
+      }
     }
   }
 }
-

--- a/lib/components/url_autocomplete_field.dart
+++ b/lib/components/url_autocomplete_field.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:jellyflix/components/custom_autocomplete_options.dart';
+import 'package:jellyflix/models/user.dart';
 import 'package:jellyflix/providers/auth_provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:jellyflix/providers/url_autocomplete_provider.dart';
+
+// Courtesy of sevenrats for the shortcuts
 
 class UrlFieldInput extends ConsumerWidget {
   const UrlFieldInput({super.key, required this.serverAddress});
@@ -12,14 +16,26 @@ class UrlFieldInput extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final savedAddress = ref.watch(allProfilesProvider);
-
-    // needed to get width of the url text filed
+    final savedAddress = ref.read(allProfilesProvider);
+    // Needed to get width of the URL text field
     // so we can assign that to the autocomplete width
     final urlTextFieldKey = GlobalKey();
 
+    // Create a custom FocusNode to listen for key events
+    final focusNode = FocusNode();
+
+    // Attach the key listener for Tab key press
+    focusNode.onKeyEvent = (FocusNode node, KeyEvent event) {
+      if (event is KeyDownEvent &&
+          event.logicalKey == LogicalKeyboardKey.enter) {
+        _selectAutocompleteOption(focusNode, serverAddress, savedAddress, ref);
+        return KeyEventResult.handled;
+      }
+      return KeyEventResult.ignored;
+    };
+
     return RawAutocomplete<String>(
-      focusNode: FocusNode(),
+      focusNode: focusNode,
       textEditingController: serverAddress,
       optionsBuilder: (TextEditingValue textEditingValue) {
         final result = savedAddress.valueOrNull
@@ -27,12 +43,15 @@ class UrlFieldInput extends ConsumerWidget {
                 .toLowerCase()
                 .contains(textEditingValue.text.toLowerCase()))
             .map((e) => e.serverAdress!);
-        return result == null || result.isEmpty
+        final options = result == null || result.isEmpty
             ? ['http://', 'https://']
                 .where((e) => e.contains(textEditingValue.text.toLowerCase()))
             : result;
+        ref.read(optionsListProvider.notifier).overwriteList(options);
+        ref.invalidate(selectedOptionProvider);
+        return options;
       },
-      onSelected: (option) => serverAddress.text = option,
+      // onSelected: (option) => serverAddress.text = option,
       optionsViewOpenDirection: OptionsViewOpenDirection.down,
       fieldViewBuilder: (context, controller, focusNode, _) {
         return TextField(
@@ -68,4 +87,36 @@ class UrlFieldInput extends ConsumerWidget {
       },
     );
   }
+
+  void _selectAutocompleteOption(
+    FocusNode focusNode,
+    TextEditingController controller,
+    AsyncValue<List<User>> savedAddress,
+    WidgetRef ref,
+  ) {
+    final selectedInd = ref.read(selectedOptionProvider);
+    // there is a potential race condition that happens occasionally essentially
+    // sometimes the optionsListProvider remains empty even after options are built
+    // I don't understand why it happens, cannot recreate it and is pretty much random,
+    // so its wrapped in a try catch
+    try {
+      final currentOptions = ref.read(optionsListProvider);
+      final user = savedAddress.valueOrNull?.firstWhere(
+        (element) =>
+            element.serverAdress!.startsWith(currentOptions[selectedInd]),
+      );
+
+      if (user != null) {
+        controller.text = user.serverAdress!;
+        // Move the cursor to the end of the text
+        controller.selection = TextSelection.fromPosition(
+          TextPosition(offset: controller.text.length),
+        );
+      }
+    } catch (e) {
+      print('Option list accessed a element out of bounds');
+      print(e);
+    }
+  }
 }
+

--- a/lib/components/url_autocomplete_field.dart
+++ b/lib/components/url_autocomplete_field.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:jellyflix/components/custom_autocomplete_options.dart';
+import 'package:jellyflix/providers/auth_provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class UrlFieldInput extends ConsumerWidget {
+  const UrlFieldInput({super.key, required this.serverAddress});
+
+  final TextEditingController serverAddress;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final savedAddress = ref.watch(allProfilesProvider);
+
+    // needed to get width of the url text filed
+    // so we can assign that to the autocomplete width
+    final urlTextFieldKey = GlobalKey();
+
+    return RawAutocomplete<String>(
+      focusNode: FocusNode(),
+      textEditingController: serverAddress,
+      optionsBuilder: (TextEditingValue textEditingValue) {
+        final result = savedAddress.valueOrNull
+            ?.where((element) => element.serverAdress!
+                .toLowerCase()
+                .contains(textEditingValue.text.toLowerCase()))
+            .map((e) => e.serverAdress!);
+        return result == null || result.isEmpty
+            ? ['http://', 'https://']
+                .where((e) => e.contains(textEditingValue.text.toLowerCase()))
+            : result;
+      },
+      onSelected: (option) => serverAddress.text = option,
+      optionsViewOpenDirection: OptionsViewOpenDirection.down,
+      fieldViewBuilder: (context, controller, focusNode, _) {
+        return TextField(
+          key: urlTextFieldKey,
+          focusNode: focusNode,
+          controller: controller,
+          decoration: InputDecoration(
+            border: const OutlineInputBorder(),
+            labelText: AppLocalizations.of(context)!.serverAddress,
+            hintText: 'http://',
+          ),
+        );
+      },
+      optionsViewBuilder: (
+        BuildContext context,
+        void Function(String) onSelected,
+        Iterable<String> options,
+      ) {
+        RenderBox? renderBox;
+        if (urlTextFieldKey.currentContext?.findRenderObject() != null) {
+          renderBox =
+              urlTextFieldKey.currentContext!.findRenderObject() as RenderBox;
+        }
+
+        return CustomAutocompleteOptions(
+          displayStringForOption: RawAutocomplete.defaultStringForOption,
+          onSelected: onSelected,
+          options: options,
+          openDirection: OptionsViewOpenDirection.down,
+          maxOptionsHeight: 100,
+          maxOptionsWidth: renderBox?.size.width ?? 300,
+        );
+      },
+    );
+  }
+}

--- a/lib/providers/url_autocomplete_provider.dart
+++ b/lib/providers/url_autocomplete_provider.dart
@@ -1,23 +1,5 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-// helpful providers to run autocompleting urls
-
-final optionsListProvider =
-    NotifierProvider.autoDispose<OptionsListNotifier, List<String>>(() {
-  return OptionsListNotifier();
-});
-
-class OptionsListNotifier extends AutoDisposeNotifier<List<String>> {
-  @override
-  List<String> build() {
-    return [];
-  }
-
-  void overwriteList(Iterable<String> element) {
-    state = [...element].toList();
-  }
-}
-
-final selectedOptionProvider = StateProvider<int>((ref) {
-  return 0;
+final selectedOptionProvider = StateProvider<String>((ref) {
+  return '';
 });

--- a/lib/providers/url_autocomplete_provider.dart
+++ b/lib/providers/url_autocomplete_provider.dart
@@ -1,0 +1,23 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// helpful providers to run autocompleting urls
+
+final optionsListProvider =
+    NotifierProvider.autoDispose<OptionsListNotifier, List<String>>(() {
+  return OptionsListNotifier();
+});
+
+class OptionsListNotifier extends AutoDisposeNotifier<List<String>> {
+  @override
+  List<String> build() {
+    return [];
+  }
+
+  void overwriteList(Iterable<String> element) {
+    state = [...element].toList();
+  }
+}
+
+final selectedOptionProvider = StateProvider<int>((ref) {
+  return 0;
+});

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,11 +1,13 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:jellyflix/components/custom_autocomplete_options.dart';
 import 'package:jellyflix/models/screen_paths.dart';
 import 'package:jellyflix/models/user.dart';
 import 'package:jellyflix/providers/auth_provider.dart';
@@ -56,15 +58,7 @@ class LoginScreen extends HookConsumerWidget {
                         const SizedBox(height: 20),
                         Padding(
                           padding: const EdgeInsets.symmetric(vertical: 10.0),
-                          child: TextField(
-                            controller: serverAddress,
-                            decoration: InputDecoration(
-                              border: const OutlineInputBorder(),
-                              labelText:
-                                  AppLocalizations.of(context)!.serverAddress,
-                              hintText: 'http://',
-                            ),
-                          ),
+                          child: UrlFieldInput(serverAddress: serverAddress),
                         ),
                         Padding(
                           padding: const EdgeInsets.symmetric(vertical: 10.0),
@@ -264,5 +258,69 @@ class LoginScreen extends HookConsumerWidget {
             'Http Code: ${resp.statusCode ?? 'Unknown'}\n\n'
             'Http Response: ${resp.statusMessage ?? 'Unknown'}\n\n'
         .trim();
+  }
+}
+
+class UrlFieldInput extends ConsumerWidget {
+  const UrlFieldInput({super.key, required this.serverAddress});
+
+  final TextEditingController serverAddress;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final savedAddress = ref.watch(allProfilesProvider);
+
+    // needed to get width of the url text filed
+    // so we can assign that to the autocomplete width
+    final urlTextFieldKey = GlobalKey();
+
+    return RawAutocomplete<String>(
+      focusNode: FocusNode(),
+      textEditingController: serverAddress,
+      optionsBuilder: (TextEditingValue textEditingValue) {
+        final result = savedAddress.valueOrNull
+            ?.where((element) => element.serverAdress!
+                .toLowerCase()
+                .contains(textEditingValue.text))
+            .map((e) => e.serverAdress!);
+        return result == null || result.isEmpty
+            ? ['http://', 'https://']
+            : result;
+      },
+      onSelected: (option) => serverAddress.text = option,
+      optionsViewOpenDirection: OptionsViewOpenDirection.down,
+      fieldViewBuilder: (context, controller, focusNode, _) {
+        return TextField(
+          key: urlTextFieldKey,
+          focusNode: focusNode,
+          controller: controller,
+          decoration: InputDecoration(
+            border: const OutlineInputBorder(),
+            labelText: AppLocalizations.of(context)!.serverAddress,
+            hintText: 'http://',
+          ),
+        );
+      },
+      optionsViewBuilder: (
+        BuildContext context,
+        void Function(String) onSelected,
+        Iterable<String> options,
+      ) {
+        RenderBox? renderBox;
+        if (urlTextFieldKey.currentContext?.findRenderObject() != null) {
+          renderBox =
+              urlTextFieldKey.currentContext!.findRenderObject() as RenderBox;
+        }
+
+        return CustomAutocompleteOptions(
+          displayStringForOption: RawAutocomplete.defaultStringForOption,
+          onSelected: onSelected,
+          options: options,
+          openDirection: OptionsViewOpenDirection.down,
+          maxOptionsHeight: 100,
+          maxOptionsWidth: renderBox?.size.width ?? 300,
+        );
+      },
+    );
   }
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -6,7 +6,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:jellyflix/components/custom_autocomplete_options.dart';
+import 'package:jellyflix/components/url_autocomplete_field.dart';
 import 'package:jellyflix/models/screen_paths.dart';
 import 'package:jellyflix/models/user.dart';
 import 'package:jellyflix/providers/auth_provider.dart';
@@ -260,67 +260,3 @@ class LoginScreen extends HookConsumerWidget {
   }
 }
 
-class UrlFieldInput extends ConsumerWidget {
-  const UrlFieldInput({super.key, required this.serverAddress});
-
-  final TextEditingController serverAddress;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final savedAddress = ref.watch(allProfilesProvider);
-
-    // needed to get width of the url text filed
-    // so we can assign that to the autocomplete width
-    final urlTextFieldKey = GlobalKey();
-
-    return RawAutocomplete<String>(
-      focusNode: FocusNode(),
-      textEditingController: serverAddress,
-      optionsBuilder: (TextEditingValue textEditingValue) {
-        final result = savedAddress.valueOrNull
-            ?.where((element) => element.serverAdress!
-                .toLowerCase()
-                .contains(textEditingValue.text.toLowerCase()))
-            .map((e) => e.serverAdress!);
-        return result == null || result.isEmpty
-            ? ['http://', 'https://']
-                .where((e) => e.contains(textEditingValue.text.toLowerCase()))
-            : result;
-      },
-      onSelected: (option) => serverAddress.text = option,
-      optionsViewOpenDirection: OptionsViewOpenDirection.down,
-      fieldViewBuilder: (context, controller, focusNode, _) {
-        return TextField(
-          key: urlTextFieldKey,
-          focusNode: focusNode,
-          controller: controller,
-          decoration: InputDecoration(
-            border: const OutlineInputBorder(),
-            labelText: AppLocalizations.of(context)!.serverAddress,
-            hintText: 'http://',
-          ),
-        );
-      },
-      optionsViewBuilder: (
-        BuildContext context,
-        void Function(String) onSelected,
-        Iterable<String> options,
-      ) {
-        RenderBox? renderBox;
-        if (urlTextFieldKey.currentContext?.findRenderObject() != null) {
-          renderBox =
-              urlTextFieldKey.currentContext!.findRenderObject() as RenderBox;
-        }
-
-        return CustomAutocompleteOptions(
-          displayStringForOption: RawAutocomplete.defaultStringForOption,
-          onSelected: onSelected,
-          options: options,
-          openDirection: OptionsViewOpenDirection.down,
-          maxOptionsHeight: 100,
-          maxOptionsWidth: renderBox?.size.width ?? 300,
-        );
-      },
-    );
-  }
-}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -280,10 +280,11 @@ class UrlFieldInput extends ConsumerWidget {
         final result = savedAddress.valueOrNull
             ?.where((element) => element.serverAdress!
                 .toLowerCase()
-                .contains(textEditingValue.text))
+                .contains(textEditingValue.text.toLowerCase()))
             .map((e) => e.serverAdress!);
         return result == null || result.isEmpty
             ? ['http://', 'https://']
+                .where((e) => e.contains(textEditingValue.text.toLowerCase()))
             : result;
       },
       onSelected: (option) => serverAddress.text = option,

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -140,6 +140,7 @@ class _PlayerSreenState extends ConsumerState<PlayerScreen> {
               );
         });
 
+        if (!context.mounted) return;
         player.stream.error.listen((error) {
           showDialog(
               context: context,


### PR DESCRIPTION
Implemented #127, had to make a custom autocomplete because the default one does not accept a controller and defaults to maxwidth.

If no addresses are found:

![image](https://github.com/user-attachments/assets/0b57d375-525b-4486-9379-b05e9308f505)

If previous address are present:

![image](https://github.com/user-attachments/assets/ec91e71b-2b65-4116-bf09-56614b7cb37d)
