### PR TITLE
Fixed downloaded files not working

### DIFF
--- a/lib/navigation/app_router.dart
+++ b/lib/navigation/app_router.dart
@@ -182,7 +182,7 @@ class AppRouter {
     },
     redirect: (context, state) async {
       final isGoingToOfflinePlayer =
-          state.matchedLocation == ScreenPaths.player;
+          state.matchedLocation == '${ScreenPaths.downloads}/${ScreenPaths.player}';
       final isGoingToDownloads = state.matchedLocation == ScreenPaths.downloads;
       final isGoingToLogin = state.matchedLocation == ScreenPaths.login;
       final isGoingToProfile = state.matchedLocation == ScreenPaths.profile;


### PR DESCRIPTION
Fixes #200 

The code was originally checking the full path against the sub route path. (/downloads/player == player)
This caused downloaded files to not show the player when disconnected from the server.